### PR TITLE
set "name" as "sexo" for radio buttons

### DIFF
--- a/first-step.html
+++ b/first-step.html
@@ -32,13 +32,13 @@
             <section class="d-flex flex-column justify-content-start align-items-start my-3">
                 <label class="text-white fw-bolder fs-3">Qual é seu sexo?</label>
                 <div class="form-check d-flex flex-row justify-content-between">
-                    <input class="form-check-input fs-3 m-1" type="radio" name="Feminino" id="feminino" value="feminino">
+                    <input class="form-check-input fs-3 m-1" type="radio" name="Sexo" id="feminino" value="feminino">
                     <label class="form-check-label text-white fs-3" for="feminino">
                     Feminino
                     </label>
                 </div>
                 <div class="form-check d-flex flex-row justify-content-between">
-                    <input class="form-check-input fs-3 m-1" type="radio" name="Masculino" id="masculino" value="masculino" checked>
+                    <input class="form-check-input fs-3 m-1" type="radio" name="Sexo" id="masculino" value="masculino" checked>
                     <label class="form-check-label text-white fs-3" for="masculino">
                     Masculino
                     </label>


### PR DESCRIPTION
Os atributos "name" não estavam iguais. Por isso, era possível selecionar sexo Masculino e Feminino ao mesmo tempo. Troquei ambos para "sexo", permitindo assim apenas um sexo selecionado por vez.